### PR TITLE
Properties.ts: ISO-8601 should be default date format

### DIFF
--- a/src/application/Properties.ts
+++ b/src/application/Properties.ts
@@ -64,7 +64,7 @@ export class Properties
 
 	public static DateDelimitors:string = "./-: ";
 	public static TimeFormat:string = "HH:mm:ss";
-	public static DateFormat:string = "DD-MM-YYYY";
+	public static DateFormat:string = "YYYY-MM-DD";
 
 	public static AttributePrefix:string = "$";
 	public static RequireAttributePrefix:boolean = false;


### PR DESCRIPTION
If a site is being used by a dane, an american and a chinese which date format should be used? As there is 1.4 billion chinese, the default date format in FutureForms should be YYYY-MM-DD, which is also ISO-8601.